### PR TITLE
Fix rubocop errors

### DIFF
--- a/rubocop
+++ b/rubocop
@@ -1,0 +1,4 @@
+#!/bin/sh
+docker-compose exec -T SERVICE_NAME_HERE bundle exec rubocop -c .rubocop.yml "$@"
+# or you can start container on each lint:
+# docker-compose run --no-deps --entrypoint= --rm SERVICE_NAME_HERE bundle exec rubocop -c .rubocop.yml "$@"


### PR DESCRIPTION
This fixes #23 

Addresses the issue with Rubocop not finding correct rubocop filepath.